### PR TITLE
fix error in 04_pinning

### DIFF
--- a/src_zh-CN/04_pinning/01_chapter.md
+++ b/src_zh-CN/04_pinning/01_chapter.md
@@ -4,7 +4,7 @@
 
 ## 为什么需要固定
 
-`Pin` 和 `Unpin` 标记 trait 搭配使用。固定保证了实现了 `Unpin` trait 的对象不会被移动。为了理解这为什么必须，我们回忆一下 `async`/`.await` 怎么工作吧。考虑以下代码：
+`Pin` 和 `Unpin` 标记 trait 搭配使用。固定保证了实现了 `!Unpin` trait 的对象不会被移动。为了理解这为什么必须，我们回忆一下 `async`/`.await` 怎么工作吧。考虑以下代码：
 
 ```rust,edition2018,ignore
 let fut_one = ...;


### PR DESCRIPTION
英文原文：
>Pinning makes it possible to guarantee that an object implementing `!Unpin` won't ever be moved.

修改前译文：
>固定保证了实现了 `Unpin` trait 的对象不会被移动。

修改后译文：
>固定保证了实现了 `!Unpin` trait 的对象不会被移动。